### PR TITLE
Add python 3.8 and 3.9 to GitHub Actions

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -85,9 +85,9 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.8', '3.9']
         include:
-        - python-version: '3.10'
+        - python-version: '3.8'
           extra: -minver
 
     steps:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -86,6 +86,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8', '3.9']
+        extra: ['']
         include:
         - python-version: '3.8'
           extra: -minver

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -85,6 +85,7 @@ jobs:
 
     strategy:
       matrix:
+        python-version: ['3.9']
         include:
         - python-version: '3.10'
           extra: -minver

--- a/environment-minver.yml
+++ b/environment-minver.yml
@@ -2,8 +2,8 @@ channels:
 - conda-forge
 - nodefaults
 dependencies:
-- fastapi
+- fastapi=0.75
 - make
 - pytest
 - pytest-cov
-- requests
+- requests=2.27

--- a/environment.yml
+++ b/environment.yml
@@ -9,4 +9,3 @@ dependencies:
 - pytest
 - pytest-cov
 - requests
-- uvicorn

--- a/ogc_api_processes_fastapi/clients.py
+++ b/ogc_api_processes_fastapi/clients.py
@@ -13,6 +13,7 @@
 # limitations under the License
 
 import abc
+from typing import List
 
 from . import models
 
@@ -25,7 +26,7 @@ class BaseClient(abc.ABC):
     @abc.abstractmethod
     def get_processes_list(
         self, limit: int, offset: int
-    ) -> list[models.ProcessSummary]:
+    ) -> List[models.ProcessSummary]:
         """
         Get all available processes.
 

--- a/ogc_api_processes_fastapi/models.py
+++ b/ogc_api_processes_fastapi/models.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-from __future__ import annotations
-
 import enum
 from typing import Any, Dict, List, Optional, Union, cast
 

--- a/ogc_api_processes_fastapi/models.py
+++ b/ogc_api_processes_fastapi/models.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import enum
-from typing import Any, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Union, cast
 
 import pydantic
 
@@ -28,7 +28,7 @@ class Metadata(pydantic.BaseModel):
 
 class AdditionalParameter(pydantic.BaseModel):
     name: str
-    value: list[Union[str, float, int, list[Any], dict[str, Any]]]
+    value: List[Union[str, float, int, List[Any], Dict[str, Any]]]
 
 
 class JobControlOptions(enum.Enum):
@@ -51,28 +51,28 @@ class Link(pydantic.BaseModel):
 
 
 class AdditionalParameters(Metadata):
-    parameters: Optional[list[AdditionalParameter]] = None
+    parameters: Optional[List[AdditionalParameter]] = None
 
 
 class DescriptionType(pydantic.BaseModel):
     title: Optional[str] = None
     description: Optional[str] = None
-    keywords: Optional[list[str]] = None
-    metadata: Optional[list[Metadata]] = None
+    keywords: Optional[List[str]] = None
+    metadata: Optional[List[Metadata]] = None
     additionalParameters: Optional[AdditionalParameters] = None
 
 
 class ProcessSummary(DescriptionType):
     id: str
     version: str
-    jobControlOptions: Optional[list[JobControlOptions]] = None
-    outputTransmission: Optional[list[TransmissionMode]] = None
-    links: Optional[list[Link]] = None
+    jobControlOptions: Optional[List[JobControlOptions]] = None
+    outputTransmission: Optional[List[TransmissionMode]] = None
+    links: Optional[List[Link]] = None
 
 
 class ProcessesList(pydantic.BaseModel):
-    processes: list[ProcessSummary]
-    links: list[Link]
+    processes: List[ProcessSummary]
+    links: List[Link]
 
 
 class MaxOccur(enum.Enum):
@@ -114,8 +114,8 @@ class SchemaItem(pydantic.BaseModel):
     uniqueItems: Optional[bool] = False
     maxProperties: Optional[PositiveInt] = None
     minProperties: Optional[PositiveInt] = cast(PositiveInt, 0)
-    required: Optional[list[str]] = pydantic.Field(None, min_items=1)
-    enum: Optional[list[Any]] = pydantic.Field(None, min_items=1)
+    required: Optional[List[str]] = pydantic.Field(None, min_items=1)
+    enum: Optional[List[Any]] = pydantic.Field(None, min_items=1)
     type: Optional[Type] = None
     description: Optional[str] = None
     format: Optional[str] = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-from typing import Iterator
+from typing import Iterator, List
 
 import pytest
 
@@ -30,7 +30,7 @@ class TestClient(clients.BaseClient):
 
     def get_processes_list(
         self, limit: int, offset: int
-    ) -> list[models.ProcessSummary]:
+    ) -> List[models.ProcessSummary]:
         processes_list = [
             models.ProcessSummary(
                 id=PROCESSES_LIST[i]["id"],


### PR DESCRIPTION
Pydantic resolves the type at runtime, so we cannot stick to 3.10 syntax for types.