### PR TITLE
[WIP] Implement pagination

### DIFF
--- a/ogc_api_processes_fastapi/clients.py
+++ b/ogc_api_processes_fastapi/clients.py
@@ -24,17 +24,10 @@ class BaseClient(abc.ABC):
     """Defines a pattern for implementing OGC API - Processes endpoints."""
 
     @abc.abstractmethod
-    def get_processes(self, limit: int, offset: int) -> List[models.ProcessSummary]:
+    def get_processes(self) -> List[models.ProcessSummary]:
         """Get all available processes.
 
         Called with `GET /processes`.
-
-        Parameters
-        ----------
-        limit : int
-            Number of processes summaries to be returned.
-        offset : int
-            Index (starting from 0) of the first process summary to be returned.
 
         Returns
         -------


### PR DESCRIPTION
@alexamici (cc @keul) this is a first attempt to implement pagination (`prev` and next `links`), for the moment only for the `GET /processes/ endpoint`. The simplest approach I could think about was to delegate pagination to the rendering of the response only (at the routes level), i.e. retrieving always all processes from the catalogue db through the client and then:
- limiting the number of processes shown
- eventually add prev and next links to the response

The opposite approach would be to pass the limit and offset parameters to the client's `get_processes()` method and query to the catalogue db only the requested set of processes, but in order to feed the logic needed to eventually add the `prev` and `next` links (which I believe should happens outside the client, at the route level) in this case the method should also return other information (e.g. to know if the end of the complete processes list has been reached).