### PR TITLE
fix inputs and outputs models: list[dict] -> dict

### DIFF
--- a/ogc_api_processes_fastapi/models.py
+++ b/ogc_api_processes_fastapi/models.py
@@ -214,15 +214,15 @@ class Subscriber(pydantic.BaseModel):
 
 
 class Execute(pydantic.BaseModel):
-    inputs: Optional[Union[InlineOrRefData, List[InlineOrRefData]]] = None
-    outputs: Optional[Output] = None
+    inputs: Optional[Dict[str, Union[InlineOrRefData, List[InlineOrRefData]]]] = None
+    outputs: Optional[Dict[str, Output]] = None
     response: Optional[Response] = Response.raw
     subscriber: Optional[Subscriber] = None
 
 
 class ProcessDescription(ProcessSummary):
-    inputs: Optional[List[Dict[str, InputDescription]]] = None
-    outputs: Optional[List[Dict[str, OutputDescription]]] = None
+    inputs: Optional[Dict[str, InputDescription]] = None
+    outputs: Optional[Dict[str, OutputDescription]] = None
 
 
 class ConInt(pydantic.ConstrainedInt):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,8 +22,8 @@ PROCESSES_DB = [
     {
         "id": f"retrieve-dataset-{i}",
         "version": f"{i}.0",
-        "inputs": [{f"input-{i}": {"schema": {"type": "string"}}}],
-        "outputs": [{f"output-{i}": {"schema": {"type": "object"}}}],
+        "inputs": {f"input-{i}": {"schema": {"type": "string"}}},
+        "outputs": {f"output-{i}": {"schema": {"type": "object"}}},
     }
     for i in range(10)
 ]


### PR DESCRIPTION
@alexamici @francesconazzaro This PR fixes models for inputs and outputs properties of the Execute and ProcessDescription models. Now, as it should be, arguments of both properties are dictionaries (and not list of dictionaries).