### PR TITLE
return document type response as job results

### DIFF
--- a/ogc_api_processes_fastapi/clients.py
+++ b/ogc_api_processes_fastapi/clients.py
@@ -15,7 +15,7 @@
 # limitations under the License
 
 import abc
-from typing import Any, Dict, List, Union
+from typing import List
 
 from . import models
 
@@ -134,7 +134,7 @@ class BaseClient(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def get_job_results(self, job_id: str) -> Union[Dict[str, Any], models.Link]:
+    def get_job_results(self, job_id: str) -> models.Results:
         """Get results of the job identified by `job_id`.
 
         Called with `GET /jobs/{job_id}/results`.
@@ -146,7 +146,7 @@ class BaseClient(abc.ABC):
 
         Returns
         -------
-        Union[Dict[str, Any], models.Link]
+        models.Results
             Job results.
 
         Raises

--- a/ogc_api_processes_fastapi/models.py
+++ b/ogc_api_processes_fastapi/models.py
@@ -261,6 +261,10 @@ class JobList(pydantic.BaseModel):
     links: List[Link]
 
 
+class Results(pydantic.BaseModel):
+    _root_: Optional[Dict[str, InlineOrRefData]] = None
+
+
 class Exception(pydantic.BaseModel):
     class Config:
         extra = pydantic.Extra.allow

--- a/ogc_api_processes_fastapi/models.py
+++ b/ogc_api_processes_fastapi/models.py
@@ -262,7 +262,7 @@ class JobList(pydantic.BaseModel):
 
 
 class Results(pydantic.BaseModel):
-    _root_: Optional[Dict[str, InlineOrRefData]] = None
+    __root__: Optional[Dict[str, InlineOrRefData]] = None
 
 
 class Exception(pydantic.BaseModel):

--- a/ogc_api_processes_fastapi/routers.py
+++ b/ogc_api_processes_fastapi/routers.py
@@ -315,22 +315,17 @@ def create_get_job_results_endpoint(
     @router.get(
         "/{job_id}/results",
         responses={
-            204: {"description": "Results of a job for async/raw/reference request"},
             200: {
-                "description": "Results of a job for async/raw/value request",
-                "content": {"application/json": {"example": "no example available"}},
+                "description": "Results of a job for async/document/value request",
+                "model": models.Response,
             },
             404: {"description": "Job not found", "model": models.Exception},
         },
         operation_id="getJobResults",
     )
-    def get_job_results(job_id: str) -> Any:
+    def get_job_results(job_id: str) -> models.Results:
         """Show results of a job."""
         response = client.get_job_results(job_id=job_id)
-        if isinstance(response, models.Link):
-            response = fastapi.Response(
-                status_code=204, headers={"Link": f"<{response.href}>"}
-            )
 
         return response
 

--- a/ogc_api_processes_fastapi/routers.py
+++ b/ogc_api_processes_fastapi/routers.py
@@ -314,11 +314,9 @@ def create_get_job_results_endpoint(
 
     @router.get(
         "/{job_id}/results",
+        response_model=models.Results,
+        response_model_exclude_unset=True,
         responses={
-            200: {
-                "description": "Results of a job for async/document/value request",
-                "model": models.Response,
-            },
             404: {"description": "Job not found", "model": models.Exception},
         },
         operation_id="getJobResults",


### PR DESCRIPTION
As briefly discussed, I changed the response of the `get_job_results` endpoint so as to adapt it to the `document` processes response type (as defined in https://docs.ogc.org/is/18-062r2/18-062r2.html#toc34).

@francesconazzaro with respect to https://github.com/ecmwf-projects/ogc-api-processes-fastapi/issues/35, this implies that now the `get_job_results` response can be an _almost_ arbitrary JSON object (it must follow the pretty loose schema defined in http://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/schemas/results.yaml).