### PR TITLE
adapt to compute api needs

### DIFF
--- a/ogc_api_processes_fastapi/clients.py
+++ b/ogc_api_processes_fastapi/clients.py
@@ -17,6 +17,8 @@
 import abc
 from typing import Any, Dict, List
 
+import fastapi
+
 from . import models
 
 
@@ -68,7 +70,10 @@ class BaseClient(abc.ABC):
 
     @abc.abstractmethod
     def post_process_execute(
-        self, process_id: str, execution_content: models.Execute
+        self,
+        process_id: str,
+        execution_content: models.Execute,
+        request: fastapi.Request,
     ) -> models.StatusInfo:
         """Post request for execution of the process identified by `process_id`.
 
@@ -81,6 +86,8 @@ class BaseClient(abc.ABC):
         execution_content : models.Execute
             Request body containing details for the process execution
             (e.g. inputs values)
+        request: fastapi.Request
+            Request
 
         Returns
         -------

--- a/ogc_api_processes_fastapi/routers.py
+++ b/ogc_api_processes_fastapi/routers.py
@@ -200,7 +200,7 @@ def create_post_process_execute_endpoint(
     ) -> Any:
         """Create a new job."""
         status_info = client.post_process_execute(
-            process_id=process_id, execution_content=request_content
+            process_id=process_id, execution_content=request_content, request=request
         )
         status_info.links = [
             models.Link(


### PR DESCRIPTION
This PR adds the possibility to pass request to the post_process_execute method of the client as needed by the Compute API.
Route is changed accordingly.