### PR TITLE
extend standard's models

### DIFF
--- a/ogc_api_processes_fastapi/models.py
+++ b/ogc_api_processes_fastapi/models.py
@@ -242,6 +242,10 @@ class JobType(enum.Enum):
     process = "process"
 
 
+class GenericObject(pydantic.BaseModel):
+    __root__: Dict[str, Any]
+
+
 class StatusInfo(pydantic.BaseModel):
     processID: Optional[str] = None
     type: JobType
@@ -253,6 +257,7 @@ class StatusInfo(pydantic.BaseModel):
     finished: Optional[datetime] = None
     updated: Optional[datetime] = None
     progress: Optional[ConInt] = None
+    metadata: Optional[GenericObject] = None
     links: Optional[List[Link]] = None
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,7 @@ class TestClient(clients.BaseClient):
         execution_content: models.Execute,
         request: fastapi.Request,
         response: fastapi.Response,
-    ) -> dict[str, Any]:
+    ) -> Dict[str, Any]:
         status_info = dict(
             jobID=1, status=models.StatusCode.accepted, type=models.JobType.process
         )


### PR DESCRIPTION
This PR extends the OGC API Processes standard. 

It introduces the model `GenericObject`, and add to `StatusInfo` an optional parameter `metadata` of type `Generic Object`.

This extension is needed to pass job's metadata not foreseen by the standard between the Compute API, the Processing API and the frontend.