### PR TITLE
Add basic filters to GET /jobs route

### DIFF
--- a/ogc_api_processes_fastapi/clients.py
+++ b/ogc_api_processes_fastapi/clients.py
@@ -15,7 +15,7 @@
 # limitations under the License
 
 import abc
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import fastapi
 
@@ -101,14 +101,29 @@ class BaseClient(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def get_jobs(self) -> responses.JobList:
+    def get_jobs(
+        self,
+        processID: Optional[List[str]] = fastapi.Query(None),
+        status: Optional[List[str]] = fastapi.Query(None),
+        limit: Optional[int] = fastapi.Query(10, ge=1, le=10000),
+    ) -> responses.JobList:
         """Get the list of submitted jobs.
 
         Called with `GET /jobs`.
 
         Parameters
         ----------
-        ...
+        processID: Optional[List[str]] = fastapi.Query(None)
+            If the parameter is specified with the operation, only jobs that have a value for
+            the processID property that matches one of the values specified for the processID
+            parameter shall be included in the response.
+        status: Optional[List[str]] = fastapi.Query(None)
+            If the parameter is specified with the operation, only jobs that have a value for
+            the status property that matches one of the specified values of the status parameter
+            shall be included in the response.
+        limit: Optional[int] = fastapi.Query(10, ge=1, le=10000)
+            The response shall not contain more jobs than specified by the optional ``limit``
+            parameter.
 
         Returns
         -------

--- a/ogc_api_processes_fastapi/clients.py
+++ b/ogc_api_processes_fastapi/clients.py
@@ -40,7 +40,7 @@ class BaseClient(abc.ABC):
 
         Returns
         -------
-        List[responses.schema["ProcessSummary"]]
+        responses.ProcessList
             List of available processes summaries.
         """
         ...
@@ -90,7 +90,7 @@ class BaseClient(abc.ABC):
 
         Returns
         -------
-        responses.schema["StatusInfo"]
+        responses.StatusInfo
             Information on the status of the submitted job.
 
         Raises
@@ -112,7 +112,7 @@ class BaseClient(abc.ABC):
 
         Returns
         -------
-        List[responses.schema["StatusInfo"]]
+        responses.JobList
             List of jobs.
         """
 
@@ -129,7 +129,7 @@ class BaseClient(abc.ABC):
 
         Returns
         -------
-        responses.schema["StatusInfo"]
+        responses.StatusInfo
             Information on the status of the job.
 
         Raises
@@ -152,7 +152,7 @@ class BaseClient(abc.ABC):
 
         Returns
         -------
-        responses.schema["Results"]
+        responses.Results
             Job results.
 
         Raises

--- a/ogc_api_processes_fastapi/main.py
+++ b/ogc_api_processes_fastapi/main.py
@@ -37,7 +37,7 @@ def register_route(
     router.add_api_route(
         name=route_name,
         path=config.ROUTES[route_name]["path"],  # type: ignore
-        response_model=response_model,  # type: ignore
+        response_model=response_model,
         response_model_exclude_unset=False,
         response_model_exclude_none=True,
         status_code=config.ROUTES[route_name].get("status_code", 200),  # type: ignore

--- a/ogc_api_processes_fastapi/main.py
+++ b/ogc_api_processes_fastapi/main.py
@@ -37,7 +37,7 @@ def register_route(
     router.add_api_route(
         name=route_name,
         path=config.ROUTES[route_name]["path"],  # type: ignore
-        response_model=response_model,
+        response_model=response_model,  # type: ignore
         response_model_exclude_unset=False,
         response_model_exclude_none=True,
         status_code=config.ROUTES[route_name].get("status_code", 200),  # type: ignore

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,7 +72,12 @@ class TestClientDefault(clients.BaseClient):
         status_info = responses.StatusInfo(jobID=1, status="accepted", type="process")
         return status_info
 
-    def get_jobs(self) -> responses.JobList:
+    def get_jobs(
+        self,
+        processID: Optional[List[str]] = fastapi.Query(None),
+        status: Optional[List[str]] = fastapi.Query(None),
+        limit: Optional[int] = fastapi.Query(10, ge=1, le=10000),
+    ) -> responses.JobList:
         jobs = [responses.StatusInfo(jobID=1, status="accepted", type="process")]
         job_list = responses.JobList(jobs=jobs)
         return job_list
@@ -141,7 +146,12 @@ class TestClientExtended(clients.BaseClient):
         status_info = responses.StatusInfo(jobID=1, status="accepted", type="process")
         return status_info
 
-    def get_jobs(self) -> JobList:
+    def get_jobs(
+        self,
+        processID: Optional[List[str]] = fastapi.Query(None),
+        status: Optional[List[str]] = fastapi.Query(None),
+        limit: Optional[int] = fastapi.Query(10, ge=1, le=10000),
+    ) -> JobList:
         jobs = [StatusInfo(jobID=1, status="accepted", type="process")]
         job_list = JobList(jobs=jobs)
         return job_list


### PR DESCRIPTION
This PR adds filters ``status`` and ``processID`` and ``limit`` query parameter to GET /jobs route, as prescribed by the OGC Processes API standard.