### PR TITLE
enable implementation of pagination

### DIFF
--- a/ogc_api_processes_fastapi/responses.py
+++ b/ogc_api_processes_fastapi/responses.py
@@ -277,9 +277,18 @@ class StatusInfo(pydantic.BaseModel):
     links: Optional[List[Link]] = None
 
 
+class PaginationQueryParameters(pydantic.BaseModel):
+    next: Optional[Dict[str, str]] = None
+    prev: Optional[Dict[str, str]] = None
+
+
 class JobList(pydantic.BaseModel):
+    class Config:
+        underscore_attrs_are_private = True
+
     jobs: List[StatusInfo]
     links: Optional[List[Link]] = None
+    _pagination_qs: Optional[PaginationQueryParameters] = None
 
 
 class Results(pydantic.BaseModel):


### PR DESCRIPTION
This PR enable client-specific implementations of pagination on the GET /jobs endpoint. It comes with https://github.com/ecmwf-projects/cads-processing-api-service/pull/55.