### PR TITLE
deprecate post /execute route in favour of post /execution

### DIFF
--- a/ogc_api_processes_fastapi/clients.py
+++ b/ogc_api_processes_fastapi/clients.py
@@ -71,14 +71,14 @@ class BaseClient(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def post_process_execute(
+    def post_process_execution(
         self,
         process_id: str = fastapi.Path(...),
         execution_content: Dict[str, Any] = fastapi.Body(...),
     ) -> responses.StatusInfo:
         """Post request for execution of the process identified by `process_id`.
 
-        Called with `POST /processes/{process_id}/execute`.
+        Called with `POST /processes/{process_id}/execution`.
 
         Parameters
         ----------

--- a/ogc_api_processes_fastapi/config.py
+++ b/ogc_api_processes_fastapi/config.py
@@ -25,7 +25,14 @@ ROUTES: Dict[str, Dict[str, Optional[Union[str, int, List[str]]]]] = {
         "path": "/processes/{process_id}/execute",
         "methods": ["POST"],
         "status_code": 201,
-        "client_method": "post_process_execute",
+        "client_method": "post_process_execution",
+        "deprecated": True,
+    },
+    "PostProcessExecution": {
+        "path": "/processes/{process_id}/execution",
+        "methods": ["POST"],
+        "status_code": 201,
+        "client_method": "post_process_execution",
     },
     "GetJobs": {
         "path": "/jobs",

--- a/ogc_api_processes_fastapi/config.py
+++ b/ogc_api_processes_fastapi/config.py
@@ -1,59 +1,61 @@
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional
 
-ROUTES: Dict[str, Dict[str, Optional[Union[str, int, List[str]]]]] = {
-    "GetLandingPage": {
-        "path": "/",
-        "methods": ["GET"],
-        "client_method": None,
-    },
-    "GetConformance": {
-        "path": "/conformance",
-        "methods": ["GET"],
-        "client_method": None,
-    },
-    "GetProcesses": {
-        "path": "/processes",
-        "methods": ["GET"],
-        "client_method": "get_processes",
-    },
-    "GetProcess": {
-        "path": "/processes/{process_id}",
-        "methods": ["GET"],
-        "client_method": "get_process",
-    },
-    "PostProcessExecute": {
-        "path": "/processes/{process_id}/execute",
-        "methods": ["POST"],
-        "status_code": 201,
-        "client_method": "post_process_execution",
-        "deprecated": True,
-    },
-    "PostProcessExecution": {
-        "path": "/processes/{process_id}/execution",
-        "methods": ["POST"],
-        "status_code": 201,
-        "client_method": "post_process_execution",
-    },
-    "GetJobs": {
-        "path": "/jobs",
-        "methods": ["GET"],
-        "client_method": "get_jobs",
-    },
-    "GetJob": {
-        "path": "/jobs/{job_id}",
-        "methods": ["GET"],
-        "client_method": "get_job",
-    },
-    "GetJobResults": {
-        "path": "/jobs/{job_id}/results",
-        "methods": ["GET"],
-        "client_method": "get_job_results",
-    },
+from pydantic import BaseModel
+
+
+class RouteConfig(BaseModel):
+    path: str
+    methods: List[str]
+    status_code: int = 200
+    client_method: Optional[str] = None
+    deprecated: Optional[bool] = None
+
+
+ROUTES: Dict[str, RouteConfig] = {
+    "GetLandingPage": RouteConfig(
+        path="/",
+        methods=["GET"],
+    ),
+    "GetConformance": RouteConfig(
+        path="/conformance",
+        methods=["GET"],
+    ),
+    "GetProcesses": RouteConfig(
+        path="/processes",
+        methods=["GET"],
+        client_method="get_processes",
+    ),
+    "GetProcess": RouteConfig(
+        path="/processes/{process_id}",
+        methods=["GET"],
+        client_method="get_process",
+    ),
+    "PostProcessExecute": RouteConfig(
+        path="/processes/{process_id}/execute",
+        methods=["POST"],
+        status_code=201,
+        client_method="post_process_execution",
+        deprecated=True,
+    ),
+    "PostProcessExecution": RouteConfig(
+        path="/processes/{process_id}/execution",
+        methods=["POST"],
+        status_code=201,
+        client_method="post_process_execution",
+    ),
+    "GetJobs": RouteConfig(
+        path="/jobs",
+        methods=["GET"],
+        client_method="get_jobs",
+    ),
+    "GetJob": RouteConfig(
+        path="/jobs/{job_id}",
+        methods=["GET"],
+        client_method="get_job",
+    ),
+    "GetJobResults": RouteConfig(
+        path="/jobs/{job_id}/results",
+        methods=["GET"],
+        client_method="get_job_results",
+    ),
 }
-"""
-    "PostProcessExecution": {
-        "path": "//processes/{process_id}/execution",
-        "methods": ["POST"],
-    },
-}
-"""

--- a/ogc_api_processes_fastapi/endpoints.py
+++ b/ogc_api_processes_fastapi/endpoints.py
@@ -194,7 +194,7 @@ def create_get_process_endpoint(
             create_self_link(str(request.url)),
             responses.Link(
                 href=urllib.parse.urljoin(
-                    str(request.base_url), f"processes/{process.id}/execute"
+                    str(request.base_url), f"processes/{process.id}/execution"
                 ),
                 rel="execute",
                 type="application/json",
@@ -207,14 +207,14 @@ def create_get_process_endpoint(
     return get_process
 
 
-def create_post_process_execute_endpoint(
+def create_post_process_execution_endpoint(
     client: clients.BaseClient,
 ) -> Callable[[fastapi.Request, fastapi.Response], responses.StatusInfo]:
-    def post_process_execute(
+    def post_process_execution(
         request: fastapi.Request,
         response: fastapi.Response,
         status_info: responses.StatusInfo = fastapi.Depends(
-            client.post_process_execute
+            client.post_process_execution
         ),
     ) -> responses.StatusInfo:
         """Create a new job."""
@@ -235,7 +235,7 @@ def create_post_process_execute_endpoint(
 
         return status_info
 
-    return post_process_execute
+    return post_process_execution
 
 
 def create_get_jobs_endpoint(
@@ -294,10 +294,11 @@ endpoints_generators = {
     "GetConformance": create_get_conformance_endpoint,
     "GetProcesses": create_get_processes_endpoint,
     "GetProcess": create_get_process_endpoint,
-    "PostProcessExecute": create_post_process_execute_endpoint,
+    "PostProcessExecution": create_post_process_execution_endpoint,
     "GetJobs": create_get_jobs_endpoint,
     "GetJob": create_get_job_endpoint,
     "GetJobResults": create_get_job_results_endpoint,
+    "PostProcessExecute": create_post_process_execution_endpoint,
 }
 
 

--- a/ogc_api_processes_fastapi/main.py
+++ b/ogc_api_processes_fastapi/main.py
@@ -36,13 +36,13 @@ def register_route(
     route_endpoint = endpoints.create_endpoint(route_name, client=client)
     router.add_api_route(
         name=route_name,
-        path=config.ROUTES[route_name]["path"],  # type: ignore
-        deprecated=config.ROUTES[route_name].get("deprecated", None),
+        path=config.ROUTES[route_name].path,
+        deprecated=config.ROUTES[route_name].deprecated,
         response_model=response_model,
         response_model_exclude_unset=False,
         response_model_exclude_none=True,
-        status_code=config.ROUTES[route_name].get("status_code", 200),  # type: ignore
-        methods=config.ROUTES[route_name]["methods"],  # type: ignore
+        status_code=config.ROUTES[route_name].status_code,
+        methods=config.ROUTES[route_name].methods,
         endpoint=route_endpoint,
     )
 

--- a/ogc_api_processes_fastapi/main.py
+++ b/ogc_api_processes_fastapi/main.py
@@ -37,6 +37,7 @@ def register_route(
     router.add_api_route(
         name=route_name,
         path=config.ROUTES[route_name]["path"],  # type: ignore
+        deprecated=config.ROUTES[route_name].get("deprecated", None),
         response_model=response_model,
         response_model_exclude_unset=False,
         response_model_exclude_none=True,

--- a/ogc_api_processes_fastapi/main.py
+++ b/ogc_api_processes_fastapi/main.py
@@ -17,7 +17,7 @@ def set_response_model(
         base_model = responses.ConfClass  # type: ignore
     else:
         base_model = typing.get_type_hints(
-            getattr(client, config.ROUTES[route_name]["client_method"])  # type: ignore
+            getattr(client, config.ROUTES[route_name].client_method)  # type: ignore
         )["return"]
     response_model = pydantic.create_model(
         route_name,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,7 +64,7 @@ class TestClientDefault(clients.BaseClient):
 
         return process
 
-    def post_process_execute(
+    def post_process_execution(
         self,
         process_id: str = fastapi.Path(...),
         execution_content: Dict[str, Any] = fastapi.Body(...),
@@ -138,7 +138,7 @@ class TestClientExtended(clients.BaseClient):
 
         return process
 
-    def post_process_execute(
+    def post_process_execution(
         self,
         process_id: str = fastapi.Path(...),
         execution_content: Dict[str, Any] = fastapi.Body(...),

--- a/tests/test_10_main.py
+++ b/tests/test_10_main.py
@@ -146,7 +146,7 @@ def test_instantiate_app_default(
     test_client_default: ogc_api_processes_fastapi.BaseClient,
 ) -> None:
     app = ogc_api_processes_fastapi.instantiate_app(client=test_client_default)
-    routes_path = [app.routes[i].path for i in range(len(app.routes))]
+    routes_path = [app.routes[i].path for i in range(len(app.routes))]  # type: ignore
 
     assert "/processes" in routes_path
     assert "/processes/{process_id}" in routes_path
@@ -168,7 +168,7 @@ def test_instantiate_app_extended(
     test_client_extended: ogc_api_processes_fastapi.BaseClient,
 ) -> None:
     app = ogc_api_processes_fastapi.instantiate_app(client=test_client_extended)
-    routes_path = [app.routes[i].path for i in range(len(app.routes))]
+    routes_path = [app.routes[i].path for i in range(len(app.routes))]  # type: ignore
 
     assert "/processes" in routes_path
     assert "/processes/{process_id}" in routes_path

--- a/tests/test_10_main.py
+++ b/tests/test_10_main.py
@@ -86,12 +86,12 @@ def test_set_resp_model_get_process_default(
     assert equal_dicts(resp_model_schema, exp_resp_model_schema, ["title"])
 
 
-def test_set_resp_model_post_process_execute_default(
+def test_set_resp_model_post_process_execution_default(
     test_client_default: ogc_api_processes_fastapi.BaseClient,
 ) -> None:
 
     resp_model = ogc_api_processes_fastapi.main.set_response_model(
-        test_client_default, "PostProcessExecute"
+        test_client_default, "PostProcessExecution"
     )
     exp_resp_model = ogc_api_processes_fastapi.responses.StatusInfo
     resp_model_schema = resp_model.schema()
@@ -150,7 +150,7 @@ def test_instantiate_app_default(
 
     assert "/processes" in routes_path
     assert "/processes/{process_id}" in routes_path
-    assert "/processes/{process_id}/execute" in routes_path
+    assert "/processes/{process_id}/execution" in routes_path
     assert "/jobs" in routes_path
     assert "/jobs/{job_id}" in routes_path
     assert "/jobs/{job_id}/results" in routes_path
@@ -172,7 +172,7 @@ def test_instantiate_app_extended(
 
     assert "/processes" in routes_path
     assert "/processes/{process_id}" in routes_path
-    assert "/processes/{process_id}/execute" in routes_path
+    assert "/processes/{process_id}/execution" in routes_path
     assert "/jobs" in routes_path
     assert "/jobs/{job_id}" in routes_path
     assert "/jobs/{job_id}/results" in routes_path

--- a/tests/test_20_endpoints.py
+++ b/tests/test_20_endpoints.py
@@ -124,13 +124,13 @@ def test_get_process(
     assert all([key in response.json() for key in exp_keys])
 
 
-def test_post_process_execute(
+def test_post_process_execution(
     test_client_default: ogc_api_processes_fastapi.BaseClient,
 ) -> None:
     app = ogc_api_processes_fastapi.main.instantiate_app(client=test_client_default)
     client = fastapi.testclient.TestClient(app)
 
-    response = client.post("/processes/dataset-1/execute", json={})
+    response = client.post("/processes/dataset-1/execution", json={})
     assert response.status_code == 201
 
     exp_keys = ("jobID", "status", "type")


### PR DESCRIPTION
This PR deprecate (leaving it available for the moment) the route POST /processes/{processID}/execute and add the route POST /processes/{processID}/execution