### PR TITLE
Make status query param an enum

### DIFF
--- a/ogc_api_processes_fastapi/models.py
+++ b/ogc_api_processes_fastapi/models.py
@@ -257,12 +257,12 @@ class ConInt(pydantic.ConstrainedInt):
     le = 100
 
 
-class StatusCode(enum.Enum):
-    accepted = "accepted"
-    running = "running"
-    successful = "successful"
-    failed = "failed"
-    dismissed = "dismissed"
+class StatusCode(str, enum.Enum):
+    accepted: str = "accepted"
+    running: str = "running"
+    successful: str = "successful"
+    failed: str = "failed"
+    dismissed: str = "dismissed"
 
 
 class JobType(enum.Enum):


### PR DESCRIPTION
This PR is necessary to make status query parameter in GET /jobs endpoint an enum.

Related:
- https://github.com/ecmwf-projects/cads-processing-api-service/pull/109
