### PR TITLE
Implement mechanism to define custom endpoints descriptions

### DIFF
--- a/ogc_api_processes_fastapi/clients.py
+++ b/ogc_api_processes_fastapi/clients.py
@@ -25,6 +25,18 @@ from . import models
 class BaseClient(abc.ABC):
     """Defines a pattern for implementing OGC API - Processes endpoints."""
 
+    endpoints_description: Dict[str, str] = {
+        "GetLandingPage": "Get landing page",
+        "GetConformance": "Get conformance classes",
+        "GetProcesses": "Get all available processes",
+        "GetProcess": "Get description of the process",
+        "PostProcessExecution": "Post request for execution of the process",
+        "GetJobs": "Get the list of submitted jobs",
+        "GetJob": "Get status information of the job",
+        "GetJobResults": "Get results of the job",
+        "DeleteJob": "Cancel the job",
+    }
+
     @abc.abstractmethod
     def get_processes(
         self, limit: Optional[int] = fastapi.Query(None)

--- a/ogc_api_processes_fastapi/main.py
+++ b/ogc_api_processes_fastapi/main.py
@@ -35,6 +35,7 @@ def register_route(
     route_endpoint = endpoints.create_endpoint(route_name, client=client)
     router.add_api_route(
         name=route_name,
+        description=client.endpoints_description.get(route_name, ""),
         response_model=response_model,
         response_model_exclude_unset=True,
         response_model_exclude_none=True,


### PR DESCRIPTION
This PR implements a mechanism to define, for each specific client, description of their endpoints to be shown in the OpenAPI documentation automatically generated by FastAPI.

**Needed by**
- https://github.com/ecmwf-projects/cads-processing-api-service/pull/206

