### PR TITLE
Remove deprecated post processes/.../execute endpoint

### DIFF
--- a/ogc_api_processes_fastapi/config.py
+++ b/ogc_api_processes_fastapi/config.py
@@ -35,14 +35,6 @@ ROUTES: Dict[str, RouteConfig] = {
         methods=["GET"],
         client_method="get_process",
     ),
-    "PostProcessExecute": RouteConfig(
-        path="/processes/{process_id}/execute",
-        summary="Execution of a process",
-        methods=["POST"],
-        status_code=201,
-        client_method="post_process_execution",
-        deprecated=True,
-    ),
     "PostProcessExecution": RouteConfig(
         path="/processes/{process_id}/execution",
         summary="Execution of a process",

--- a/ogc_api_processes_fastapi/endpoints.py
+++ b/ogc_api_processes_fastapi/endpoints.py
@@ -322,7 +322,6 @@ endpoints_generators = {
     "GetJob": create_get_job_endpoint,
     "GetJobResults": create_get_job_results_endpoint,
     "DeleteJob": create_delete_job_endpoint,
-    "PostProcessExecute": create_post_process_execution_endpoint,
 }
 
 


### PR DESCRIPTION
This PR removes the deprecated `POST processes/.../execute` endpoint.

**Needs**:
- https://github.com/ecmwf-projects/cads-api-client/pull/71