### PR TITLE
Enable configurable API metadata

### DIFF
--- a/ogc_api_processes_fastapi/main.py
+++ b/ogc_api_processes_fastapi/main.py
@@ -1,7 +1,7 @@
 """API routes registration and initialization."""
 
 import typing
-from typing import Callable
+from typing import Any, Callable
 
 import fastapi
 import pydantic
@@ -60,8 +60,26 @@ def instantiate_app(
     exception_handler: Callable[
         [fastapi.Request, exceptions.OGCAPIException], fastapi.responses.JSONResponse
     ] = exceptions.ogc_api_exception_handler,
+    **kwargs: Any,
 ) -> fastapi.FastAPI:
-    app = fastapi.FastAPI()
+    """Instantiate FastAPI application.
+
+    Parameters
+    ----------
+    client : clients.BaseClient
+        Client to be used for API requests.
+    exception_handler : Callable[[fastapi.Request, exceptions.OGCAPIException],
+    fastapi.responses.JSONResponse], optional
+        Exception handler, by default exceptions.ogc_api_exception_handler
+    **kwargs : Any
+        Additional parameters passed to `fastapi.Fastapi()`.
+
+    Returns
+    -------
+    fastapi.FastAPI
+        FastAPI application.
+    """
+    app = fastapi.FastAPI(**kwargs)
     router = instantiate_router(client)
     app.include_router(router)
     app = exceptions.include_exception_handlers(app, exception_handler)

--- a/ogc_api_processes_fastapi/models.py
+++ b/ogc_api_processes_fastapi/models.py
@@ -34,14 +34,14 @@ class AdditionalParameter(pydantic.BaseModel):
 
 
 class JobControlOptions(enum.Enum):
-    sync_execute: str = "sync-execute"
-    async_execute: str = "async-execute"
-    dismiss: str = "dismiss"
+    sync_execute = "sync-execute"
+    async_execute = "async-execute"
+    dismiss = "dismiss"
 
 
 class TransmissionMode(enum.Enum):
-    value: str = "value"
-    reference: str = "reference"
+    value = "value"
+    reference = "reference"
 
 
 class PaginationQueryParameters(pydantic.BaseModel):
@@ -260,11 +260,11 @@ ConInt = typing_extensions.Annotated[int, pydantic.Field(ge=0, le=100)]
 
 
 class StatusCode(str, enum.Enum):
-    accepted: str = "accepted"
-    running: str = "running"
-    successful: str = "successful"
-    failed: str = "failed"
-    dismissed: str = "dismissed"
+    accepted = "accepted"
+    running = "running"
+    successful = "successful"
+    failed = "failed"
+    dismissed = "dismissed"
 
 
 class JobType(enum.Enum):


### PR DESCRIPTION
This PR enables configuring API metadata (such as title, description, etc) when instantiating the application.

**Needed by**:
- https://github.com/ecmwf-projects/cads-processing-api-service/pull/244